### PR TITLE
Update TimerHelper.cs

### DIFF
--- a/talis.xivplugin.twintania/Helpers/TimerHelper.cs
+++ b/talis.xivplugin.twintania/Helpers/TimerHelper.cs
@@ -148,7 +148,7 @@ namespace Talis.XIVPlugin.Twintania.Helpers
                 _timeToEventSeconds--;
                 if (_timeToEventSeconds <= 10)
                 {
-                    SoundPlayerHelper.PlayCached("Plugins/Talis.XIVPlugin.Twintania/Counting/" + _timeToEventSeconds + @".mp3", Volume);
+                    SoundPlayerHelper.PlayCached("Plugins\\Talis.XIVPlugin.Twintania\\Counting\\" + _timeToEventSeconds + @".mp3", Volume);
                 }
             }
             else if (_timeToEventCurrent <= 0.00)


### PR DESCRIPTION
after initial counting play; prevents other cached files from being loaded as \ is required for path, vs / which causes a "dual caching" and the helper can't distinguish which sound to play.
